### PR TITLE
bump LSP4J version 0.14.0 to 0.20.1

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.lemminx;
 
-import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.*;
+import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -365,9 +365,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 					return Either3.forSecond((PrepareRenameResult)either.get());
 				}
 			}else {
-				return null;
+				return Either3.forThird(new PrepareRenameDefaultBehavior());
 			}
-			//return getXMLLanguageService().prepareRename3(xmlDocument, params.getPosition(), cancelChecker);//comment at 2023/3/2 for update lsp4j 0.20.1
 		});
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -359,12 +359,12 @@ public class XMLTextDocumentService implements TextDocumentService {
 		return computeDOMAsync(params.getTextDocument(), (xmlDocument, cancelChecker) -> {
 			Either<Range, PrepareRenameResult> either = getXMLLanguageService().prepareRename(xmlDocument, params.getPosition(), cancelChecker);
 			if (either != null) {
-				if(either.isLeft()) {
-					return Either3.forFirst((Range)either.get());
-				}else {
-					return Either3.forSecond((PrepareRenameResult)either.get());
+				if (either.isLeft()) {
+					return Either3.forFirst((Range) either.get());
+				} else {
+					return Either3.forSecond((PrepareRenameResult) either.get());
 				}
-			}else {
+			} else {
 				return Either3.forThird(new PrepareRenameDefaultBehavior());
 			}
 		});

--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1526,8 +1526,31 @@
 		}]
 	},
 	{
+		"name": "org.eclipse.lsp4j.NotebookDocumentClientCapabilities",
+		"allDeclaredFields": true,
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
+		"name": "org.eclipse.lsp4j.NotebookDocumentSyncClientCapabilities",
+		"allDeclaredFields": true,
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
 		"name": "org.eclipse.lsp4j.OnTypeFormattingCapabilities",
 		"allDeclaredFields": true,
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
+		"name": "org.eclipse.lsp4j.adapters.DocumentDiagnosticReportTypeAdapter",
 		"methods": [{
 			"name": "<init>",
 			"parameterTypes": []

--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1692,6 +1692,12 @@
 		}]
 	},
 	{
+		"name": "org.eclipse.lsp4j.PrepareRenameDefaultBehavior",
+		"fields": [{
+			"name": "defaultBehavior"
+		}]
+	},
+	{
 		"name": "org.eclipse.lsp4j.ResourceOperation",
 		"allDeclaredFields": true
 	},

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,10 @@
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<lsp4j.version>0.14.0</lsp4j.version>
-		<junit.version>5.9.1</junit.version>
+		<!--<lsp4j.version>0.14.0</lsp4j.version>-->
+		<lsp4j.version>0.20.1</lsp4j.version>
+		<org.eclipse.xtend.lib.version>2.29.0</org.eclipse.xtend.lib.version>
+		<junit.version>5.9.2</junit.version>
 	</properties>
 	<url>https://github.com/eclipse/lemminx</url>
 	<licenses>
@@ -46,7 +48,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.10</version>
+				<version>2.10.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.lsp4j</groupId>
@@ -85,11 +87,11 @@
 				<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
 				<version>${lsp4j.version}</version>
 			</dependency>
-			<dependency>
+			<!--<dependency>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>org.eclipse.xtend.lib</artifactId>
-				<version>2.16.0.M1</version>
-			</dependency>
+				<version>${org.eclipse.xtend.lib.version}</version>
+			</dependency>-->
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!--<lsp4j.version>0.14.0</lsp4j.version>-->
 		<lsp4j.version>0.20.1</lsp4j.version>
 		<org.eclipse.xtend.lib.version>2.29.0</org.eclipse.xtend.lib.version>
 		<junit.version>5.9.2</junit.version>
@@ -87,11 +86,6 @@
 				<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
 				<version>${lsp4j.version}</version>
 			</dependency>
-			<!--<dependency>
-				<groupId>org.eclipse.xtend</groupId>
-				<artifactId>org.eclipse.xtend.lib</artifactId>
-				<version>${org.eclipse.xtend.lib.version}</version>
-			</dependency>-->
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<lsp4j.version>0.20.1</lsp4j.version>
-		<org.eclipse.xtend.lib.version>2.29.0</org.eclipse.xtend.lib.version>
 		<junit.version>5.9.2</junit.version>
 	</properties>
 	<url>https://github.com/eclipse/lemminx</url>


### PR DESCRIPTION
bump junit version 5.9.1 to 5.9.2
bump gson version 2.10 to 2.10.1
remove org.eclipse.xtend.lib from dependencyManagement(Transitive by LSP4J)